### PR TITLE
Allow to customise alert message

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ After that, copy the generated binary `bin/grafana` into the BitBar plugins dire
 
 This plugin looks for the Grafana API key from the macOS keychain. Make sure to add an entry using the hostname as the entry name, and `apikey` as the account name. Once the item is created, make sure to run the plugin executable at least once and give permanent access to the keychain entry.
 
+You can customise the alert's prefix by setting `GRAFANA_ALERT_PREFIX` environment variable when building. It defaults to `Grafana: ` (whitespace included so you can omit it if you want).
+
 ## Contributing
 
 1. Fork it (<https://github.com/waj/bitbar-grafana/fork>)

--- a/src/grafana.cr
+++ b/src/grafana.cr
@@ -7,11 +7,12 @@ apikey = Security.find_generic_password(hostname, "apikey")
 headers = HTTP::Headers{"Authorization" => "Bearer #{apikey}"}
 response = HTTP::Client.get("https://#{hostname}/api/alerts?state=alerting", headers)
 alerts = JSON.parse(response.body).as_a
+alert_prefix = {{ env("GRAFANA_ALERT_PREFIX") }} || "Grafana: "
 
 if alerts.size == 0
-  puts "Grafana: ✅"
+  puts "#{alert_prefix}✅"
 else
-  puts "Grafana: ‼️"
+  puts "#{alert_prefix}‼️"
 end
 
 puts "---"


### PR DESCRIPTION
Instead of showing `Grafana: ✅` on the status bar, allow to set a custom prefix at build time by setting the `GRAFANA_ALERT_PREFIX` variable. It defaults to the previous value.